### PR TITLE
Add custom query settings support

### DIFF
--- a/src/app/dashboard/[package_name]/page.js
+++ b/src/app/dashboard/[package_name]/page.js
@@ -140,14 +140,17 @@ export default async function Dashboard({ params, searchParams }) {
       <div className='relative isolate'>
         <div className='pt-12 w-11/12 lg:w-full xl:w-11/12 mx-auto lg:px-16 flex flex-row gap-4  justify-between'>
           <PackageDetails name={package_name} {...packageDetails[1][0]} />
+          
           <div className='flex flex-col'>
+          <Suspense key={key} fallback={<Loading />}>
             <PackageBadge package_name={package_name}
                     version={version}
                     min_date={min_date}
                     max_date={max_date}
                     country_code={country_code} />
-            
+            </Suspense>
           </div>
+          
         </div>
         <div className='mt-4 flex flex-col w-11/12 lg:w-full xl:w-11/12 lg:px-16 mx-auto items-end'>
         <PlaygroundLink package_name={package_name} />


### PR DESCRIPTION
This PR adds support to add custom query settings using environment variable. 

Related: https://github.com/ClickHouse/clickpy/issues/119

Example: 

```
QUERY_CUSTOM_SETTINGS={"getPackageRanking": {"allow_experimental_parallel_reading_from_replicas": 1, "max_threads": 30}}
```

Add automatically to the query getPackageRanking the query level settings `allow_experimental_parallel_reading_from_replicas` and `max_threads`