### PR TITLE
Fix clear selection button issue

### DIFF
--- a/src/components/Charts/Bar.jsx
+++ b/src/components/Charts/Bar.jsx
@@ -106,7 +106,7 @@ export default function Bar({ data, stack, onSelect, link }) {
     },
     series: series,
     brush: {
-      toolbox: ['lineX', 'clear'],
+      toolbox: ['lineX'],
       brushType: 'lineX',
       brushMode: 'single',
       transformable: false
@@ -141,6 +141,10 @@ export default function Bar({ data, stack, onSelect, link }) {
     }
   };
 
+  const onClearSelection = () => {
+    console.log("clear selection")
+  };
+
   const onChartReady = (echarts) => {
     setLoading(false);
   };
@@ -164,7 +168,7 @@ export default function Bar({ data, stack, onSelect, link }) {
         onChartReady={onChartReady}
         onEvents={{
           brushEnd: onBrushEnd
-        }}
+          }}
         shouldSetOption={(prevProps, currentProps) => {
           const shouldRender = !isEqual(prevProps, currentProps);
           if (shouldRender) {

--- a/src/components/Charts/Line.jsx
+++ b/src/components/Charts/Line.jsx
@@ -118,7 +118,7 @@ export default function Line({ data, onSelect, onClear, link }) {
       }
     },
     brush: {
-      toolbox: ['lineX', 'clear'],
+      toolbox: ['lineX'],
       brushType: 'lineX',
       brushMode: 'single',
       transformable: false
@@ -161,7 +161,7 @@ export default function Line({ data, onSelect, onClear, link }) {
   return (
     <div
       className='relative rounded-lg bg-slate-850 border border-slate-700 h-full justify-between flex flex-col'
-      onMouseMove={onMouseOver}
+      onMouseOver={onMouseOver}
       onMouseOut={onMouseOut}
       onDoubleClickCapture={onDoubleClick}>
       <div className='px-[4px] pt-[4px] flex-row flex justify-end'>

--- a/src/components/Charts/MultiLine.jsx
+++ b/src/components/Charts/MultiLine.jsx
@@ -108,7 +108,7 @@ export default function MultiLine({ data, stack, fill, onSelect, link }) {
     },
     series: series,
     brush: {
-      toolbox: ['lineX', 'clear'],
+      toolbox: ['lineX'],
       brushType: 'lineX',
       brushMode: 'single',
       transformable: false


### PR DESCRIPTION
Remove not working clear selection button. We can refresh the page to revert changes. 

Fix tooltip over on line chart

fix #156 