### PR TITLE
Restrict crawling to homepage and dashboards, trim sitemap

### DIFF
--- a/src/app/dashboard/[package_name]/page.js
+++ b/src/app/dashboard/[package_name]/page.js
@@ -124,7 +124,7 @@ export default async function Dashboard({ params, searchParams }) {
               Powered by &nbsp;
               <a
                 className='text-primary-300 hover:underline'
-                href='http://clickhouse.com/'
+                href='https://clickhouse.com/'
                 target='_blank'>
                 ClickHouse
               </a>

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,8 +1,9 @@
- export default function robots(){
+export default function robots() {
   return {
     rules: {
       userAgent: '*',
-      allow: '/',
+      allow: ['/$', '/dashboard/*'],
+      disallow: '/',
     },
     sitemap: 'https://clickpy.clickhouse.com/sitemap.xml',
   }

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -16,7 +16,7 @@ SELECT
 FROM pypi.pypi_downloads
 GROUP BY project
 ORDER BY c DESC
-LIMIT 49999
+LIMIT 1000
 `;
 
 export default async function sitemap() {
@@ -31,22 +31,18 @@ export default async function sitemap() {
         })
       }
 
-    // Create dynamic sitemap entries based on the rows
     const dynamicEntries = projects.map(project => ({
         url: `https://clickpy.clickhouse.com/dashboard/${encodeURIComponent(project)}`,
-        lastModified: new Date(),
         changeFrequency: 'daily',
         priority: 0.7,
     }));
 
-    // Simplified static entries for your sitemap
     const staticEntries = [
         {
-            url: 'https://clickpy.clickhouse.com/dashboard/',
-            lastModified: new Date(),
+            url: 'https://clickpy.clickhouse.com/',
             changeFrequency: 'yearly',
             priority: 1,
-        }
+        },
     ];
 
     return [...staticEntries, ...dynamicEntries];

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,7 +27,7 @@ export default function Header() {
                 Powered by &nbsp;
                 <a
                   className='text-primary-300 hover:underline'
-                  href='http://clickhouse.com/'
+                  href='https://clickhouse.com/'
                   target='_blank'>
                   ClickHouse
                 </a>

--- a/src/components/PackageDetails.jsx
+++ b/src/components/PackageDetails.jsx
@@ -13,7 +13,7 @@ export default function PackageDetails({
   return (
     <div>
       <div className='flex items-center text-center'>
-        <p className='text-4xl font-bold mr-5'>{name}</p>
+        <h1 className='text-4xl font-bold mr-5'>{name} PyPI stats</h1>
         {home_page && (
           <a href={home_page} target='_blank' className='text-center pt-2'>
             <button type='button'>


### PR DESCRIPTION
## Summary
- Update `robots.txt` to allow only `/` and `/dashboard/*`, disallow everything else
- Trim sitemap from top 50k PyPI projects to top 1k
- Drop misleading build-time `lastModified` values from sitemap entries
- Replace `/dashboard/` static sitemap entry with the homepage `/`

## Test plan
- [ ] Verify `https://clickpy.clickhouse.com/robots.txt` renders:
  ```
  User-agent: *
  Allow: /$
  Allow: /dashboard/*
  Disallow: /
  Sitemap: https://clickpy.clickhouse.com/sitemap.xml
  ```
- [ ] Verify `https://clickpy.clickhouse.com/sitemap.xml` contains the homepage and ~1,000 `/dashboard/<project>` URLs, no `lastmod` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)