### PR TITLE
Fix false dependents from prefix matching in `getDependents`

### DIFF
--- a/src/utils/clickhouse.js
+++ b/src/utils/clickhouse.js
@@ -186,7 +186,10 @@ export async function getDependents({ package_name, version, min_date, max_date,
             WHERE project IN (
                 SELECT name
                 FROM ${PYPI_DATABASE}.projects
-                WHERE arrayExists(e -> (e LIKE {package_name:String} || '%'), requires_dist) != 0 AND name != {package_name:String}
+                WHERE arrayExists(e -> (
+                    startsWith(e, {package_name:String})
+                    AND substr(e, length({package_name:String}) + 1, 1) IN ('', ' ', '\t', '(', '[', ';', '<', '>', '=', '!', '~', '@')
+                ), requires_dist) AND name != {package_name:String}
                 GROUP BY name
             ) AND ${country_code ? `country_code={country_code:String}` : '1=1'} AND ${type ? `type={type:String}` : '1=1'} AND (date >= {min_date:String}::Date32) AND (date < {max_date:String}::Date32)
             GROUP BY project


### PR DESCRIPTION
Fixes false dependents when another package name extends the queried one. Closes #234.

## Solution

Match `requires_dist` entries only at a [PEP 508](https://github.com/pypa/packaging.python.org/blob/e0c56aa/source/specifications/dependency-specifiers.rst?plain=1#L498-L606) boundary after the package name (`getDependents()` in [`src/utils/clickhouse.js`](https://github.com/ClickHouse/clickpy/blob/main/src/utils/clickhouse.js)):

```sql
arrayExists(e -> (
    startsWith(e, {package_name:String})
    AND substr(e, length({package_name:String}) + 1, 1) IN ('', ' ', '\t', '(', '[', ';', '<', '>', '=', '!', '~', '@')
), requires_dist)
```

Same semantics as `getDependencies()`, but without scanning every `requires_dist` with `extract()`.

## Validation

Distinct dependent counts on `pypi.projects` (UI shows top 9 by downloads only):

| Package | Before | After |
|---|---:|---:|
| `opentelemetry-instrumentation-re` (repro) | 268 | **0** |
| `opentelemetry-instrumentation-requests` | 229 | 229 |
| `requests` | 92,874 | 91,490 (−1,384) |

Playground checks:

- [Set diff](https://sql.clickhouse.com/?query=V0lUSCAncmVxdWVzdHMnIEFTIHBrZwpTRUxFQ1QKICAgIGNvdW50RGlzdGluY3RJZihuYW1lLCBhcnJheUV4aXN0cyhlIC0-IChlIExJS0UgcGtnIHx8ICclJyksIHJlcXVpcmVzX2Rpc3QpKSBBUyBvbGRfYywKICAgIGNvdW50RGlzdGluY3RJZihuYW1lLCBhcnJheUV4aXN0cyhlIC0-ICgKICAgIHN0YXJ0c1dpdGgoZSwgcGtnKQogICAgQU5EIHN1YnN0cihlLCBsZW5ndGgocGtnKSArIDEsIDEpIElOICgnJywgJyAnLCAnXHQnLCAnKCcsICdbJywgJzsnLCAnPCcsICc-JywgJz0nLCAnIScsICd-JywgJ0AnKQogICAgKSwgcmVxdWlyZXNfZGlzdCkpIEFTIG5ld19jLAogICAgY291bnREaXN0aW5jdElmKG5hbWUsCiAgICBhcnJheUV4aXN0cyhlIC0-IChlIExJS0UgcGtnIHx8ICclJyksIHJlcXVpcmVzX2Rpc3QpCiAgICBBTkQgTk9UIGFycmF5RXhpc3RzKGUgLT4gKAogICAgICAgIHN0YXJ0c1dpdGgoZSwgcGtnKQogICAgICAgIEFORCBzdWJzdHIoZSwgbGVuZ3RoKHBrZykgKyAxLCAxKSBJTiAoJycsICcgJywgJ1x0JywgJygnLCAnWycsICc7JywgJzwnLCAnPicsICc9JywgJyEnLCAnficsICdAJykKICAgICksIHJlcXVpcmVzX2Rpc3QpCiAgICApIEFTIG9ubHlfb2xkLAogICAgY291bnREaXN0aW5jdElmKG5hbWUsCiAgICBOT1QgYXJyYXlFeGlzdHMoZSAtPiAoZSBMSUtFIHBrZyB8fCAnJScpLCByZXF1aXJlc19kaXN0KQogICAgQU5EIGFycmF5RXhpc3RzKGUgLT4gKAogICAgICAgIHN0YXJ0c1dpdGgoZSwgcGtnKQogICAgICAgIEFORCBzdWJzdHIoZSwgbGVuZ3RoKHBrZykgKyAxLCAxKSBJTiAoJycsICcgJywgJ1x0JywgJygnLCAnWycsICc7JywgJzwnLCAnPicsICc9JywgJyEnLCAnficsICdAJykKICAgICksIHJlcXVpcmVzX2Rpc3QpCiAgICApIEFTIG9ubHlfbmV3CkZST00gcHlwaS5wcm9qZWN0cwpXSEVSRSBuYW1lICE9IHBrZw) — `only_new = 0` (no false negatives)
- [Removed lines (sample)](https://sql.clickhouse.com/?query=U0VMRUNUIG5hbWUsIHJlcQpGUk9NICgKICBTRUxFQ1QgbmFtZSwgYXJyYXlKb2luKHJlcXVpcmVzX2Rpc3QpIEFTIHJlcQogIEZST00gcHlwaS5wcm9qZWN0cwogIFdIRVJFIG5hbWUgIT0gJ3JlcXVlc3RzJwogICAgQU5EIGFycmF5RXhpc3RzKGUgLT4gKGUgTElLRSAncmVxdWVzdHMlJyksIHJlcXVpcmVzX2Rpc3QpCiAgICBBTkQgTk9UIGFycmF5RXhpc3RzKGUgLT4gKAogICAgICBzdGFydHNXaXRoKGUsICdyZXF1ZXN0cycpCiAgICAgIEFORCBzdWJzdHIoZSwgbGVuZ3RoKCdyZXF1ZXN0cycpICsgMSwgMSkgSU4gKCcnLCAnICcsICdcdCcsICcoJywgJ1snLCAnOycsICc8JywgJz4nLCAnPScsICchJywgJ34nLCAnQCcpCiAgICApLCByZXF1aXJlc19kaXN0KQopCldIRVJFIHN0YXJ0c1dpdGgocmVxLCAncmVxdWVzdHMnKQogIEFORCBzdWJzdHIocmVxLCBsZW5ndGgoJ3JlcXVlc3RzJykgKyAxLCAxKSBOT1QgSU4gKCcnLCAnICcsICdcdCcsICcoJywgJ1snLCAnOycsICc8JywgJz4nLCAnPScsICchJywgJ34nLCAnQCcpCk9SREVSIEJZIGxlbmd0aChyZXEpIERFU0MKTElNSVQgMjU=) — dropped matches are `requests-*`, not bare `requests`
- [Control unchanged](https://sql.clickhouse.com/?query=U0VMRUNUCiAgICBjb3VudERpc3RpbmN0SWYobmFtZSwgYXJyYXlFeGlzdHMoZSAtPiAoZSBMSUtFICdvcGVudGVsZW1ldHJ5LWluc3RydW1lbnRhdGlvbi1yZXF1ZXN0cyUnKSwgcmVxdWlyZXNfZGlzdCkpIEFTIG9sZF9jLAogICAgY291bnREaXN0aW5jdElmKG5hbWUsIGFycmF5RXhpc3RzKGUgLT4gKAogICAgc3RhcnRzV2l0aChlLCAnb3BlbnRlbGVtZXRyeS1pbnN0cnVtZW50YXRpb24tcmVxdWVzdHMnKQogICAgQU5EIHN1YnN0cihlLCBsZW5ndGgoJ29wZW50ZWxlbWV0cnktaW5zdHJ1bWVudGF0aW9uLXJlcXVlc3RzJykgKyAxLCAxKSBJTiAoJycsICcgJywgJ1x0JywgJygnLCAnWycsICc7JywgJzwnLCAnPicsICc9JywgJyEnLCAnficsICdAJykKICAgICksIHJlcXVpcmVzX2Rpc3QpKSBBUyBuZXdfYwpGUk9NIHB5cGkucHJvamVjdHMKV0hFUkUgbmFtZSAhPSAnb3BlbnRlbGVtZXRyeS1pbnN0cnVtZW50YXRpb24tcmVxdWVzdHMn) — repro control stays 229 → 229
- [Leading whitespace audit](https://sql.clickhouse.com/?query=U0VMRUNUCiAgY291bnQoKSBBUyB0b3RhbF9yZXF1aXJlc19kaXN0X2VudHJpZXMsCiAgY291bnRJZih0cmltTGVmdChlKSAhPSBlKSBBUyBsZWFkaW5nX3dzX3RyaW1sZWZ0LAogIGNvdW50SWYobWF0Y2goZSwgJ15bIFx0XSsnKSkgQVMgbGVhZGluZ190YWJfc3BhY2VfcmVnZXgsCiAgY291bnRJZihtYXRjaChlLCAnXlsgXHRcclxuXGZcdl0nKSkgQVMgbGVhZGluZ19hc2NpaV93cwpGUk9NIHB5cGkucHJvamVjdHMKQVJSQVkgSk9JTiByZXF1aXJlc19kaXN0IEFTIGUK) — 0 / 126,288,944 entries (same gap as old `LIKE`)

`extract()` cross-check for `requests`: 91,490 vs 91,491 — extra hit is garbage (`requests.txt`).

## Test plan

- [x] Repro → 0 dependents; control → 229 unchanged
- [x] `requests` set diff: `only_new = 0`, `only_old = 1,384`
- [x] Whitespace audit: 0 / 126,288,944
- [x] UI: [repro dashboard](https://clickpy.clickhouse.com/dashboard/opentelemetry-instrumentation-re) → Dependents empty

![Dependents tab reads "No dependents" for opentelemetry-instrumentation-re after the fix](https://github.com/user-attachments/assets/2d17d46c-732b-4c0d-9773-7bb0547354ee)

## Notes
* Query-only fix (`src/utils/clickhouse.js`).
* Rejected alternative: `extract(e, '^[a-zA-Z0-9\\-_]+') = {package_name}` — equivalent but costlier on the all-projects scan.
