### PR TITLE
fix: don't mis-split event namespace when it contains a dot

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "node --import ./test/register.mjs --test \"test/*.test.js\"",
     "postinstall": "patch-package"
   },
   "dependencies": {

--- a/src/lib/galaxy/client/index.js
+++ b/src/lib/galaxy/client/index.js
@@ -41,7 +41,19 @@ export class GalaxyClient {
     const { interaction, ...eventProperties } = properties ?? {
       interaction: 'click'
     };
-    const [namespace, component, eventName] = event.split('.');
+    // `event` is "<namespace>.<component>.<eventName>". `namespace` is free-form
+    // (it can be a package/gem name, which may itself contain dots, e.g.
+    // "dashboard: ruamel.yaml" or "dashboard: llm.rb"), while `component` and
+    // `eventName` are always short fixed literals chosen by the caller (e.g.
+    // "window", "load") and never contain dots. Splitting naively on every "."
+    // and taking the first three parts silently truncates/misaligns
+    // component/eventName whenever namespace has a dot in it. Instead, take the
+    // last two segments as component/eventName and treat everything before
+    // them as namespace, which is safe either way and fixes that case.
+    const parts = event.split('.');
+    const eventName = parts.pop();
+    const component = parts.pop();
+    const namespace = parts.join('.');
     const payloadProperties = this.getPayloadProperties();
     const galaxyEvent = {
       application: this.application,

--- a/test/extensionless-resolver.mjs
+++ b/test/extensionless-resolver.mjs
@@ -1,0 +1,20 @@
+// The app source uses extensionless relative imports (e.g. `import { logFns }
+// from '../logging'`), which webpack/Next.js resolve at build time but Node's
+// native ESM resolver does not. This loader hook lets `node --test` import the
+// source directly by retrying a failed relative specifier with a `.js`
+// extension appended. Registered via `--import ./test/register.mjs`.
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (error) {
+    if (
+      (error?.code === 'ERR_MODULE_NOT_FOUND' ||
+        error?.code === 'ERR_UNSUPPORTED_DIR_IMPORT') &&
+      (specifier.startsWith('./') || specifier.startsWith('../')) &&
+      !/\.[cm]?js$/.test(specifier)
+    ) {
+      return await nextResolve(`${specifier}.js`, context);
+    }
+    throw error;
+  }
+}

--- a/test/galaxy-client.test.js
+++ b/test/galaxy-client.test.js
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { GalaxyClient } from '../src/lib/galaxy/client/index.js';
+
+function trackAndGetLastEvent(client, event, properties) {
+  client.track(event, properties);
+  return client.eventsQueue[client.eventsQueue.length - 1];
+}
+
+function makeClient() {
+  return new GalaxyClient({
+    application: 'TEST',
+    getUserId: () => 'test-user',
+    getSessionId: () => 'test-session',
+    getContext: () => ({})
+  });
+}
+
+test('namespace without dots splits as before', () => {
+  const e = trackAndGetLastEvent(makeClient(), 'landing.window.load');
+  assert.equal(e.namespace, 'landing');
+  assert.equal(e.component, 'window');
+  assert.equal(e.event, 'load');
+});
+
+test('namespace with one dot (real ClickGems anomaly: llm.rb)', () => {
+  const e = trackAndGetLastEvent(makeClient(), 'dashboard: llm.rb.window.load');
+  assert.equal(e.namespace, 'dashboard: llm.rb');
+  assert.equal(e.component, 'window');
+  assert.equal(e.event, 'load');
+});
+
+test('namespace with one dot (real ClickGems anomaly: savon-ng-1.6)', () => {
+  const e = trackAndGetLastEvent(makeClient(), 'dashboard: savon-ng-1.6.window.blur');
+  assert.equal(e.namespace, 'dashboard: savon-ng-1.6');
+  assert.equal(e.component, 'window');
+  assert.equal(e.event, 'blur');
+});
+
+test('namespace with one dot (dormant ClickPy case: ruamel.yaml)', () => {
+  const e = trackAndGetLastEvent(makeClient(), 'dashboard: ruamel.yaml.window.load');
+  assert.equal(e.namespace, 'dashboard: ruamel.yaml');
+  assert.equal(e.component, 'window');
+  assert.equal(e.event, 'load');
+});
+
+test('click-style event (nav.query.select) is unaffected', () => {
+  const e = trackAndGetLastEvent(makeClient(), 'nav.query.select', { interaction: 'click' });
+  assert.equal(e.namespace, 'nav');
+  assert.equal(e.component, 'query');
+  assert.equal(e.event, 'select');
+});

--- a/test/register.mjs
+++ b/test/register.mjs
@@ -1,0 +1,4 @@
+// Registers the extensionless-import resolver hook so `node --test` can import
+// the bundler-style app source. Usage: node --import ./test/register.mjs --test test/
+import { register } from 'node:module';
+register('./extensionless-resolver.mjs', import.meta.url);


### PR DESCRIPTION
## What
`GalaxyClient.track()` split the event string on every `.` and kept the
first 3 parts, so a `namespace` containing a literal dot (e.g. a package
name like `ruamel.yaml`) shifted the split and corrupted `component`/`event`.

## Fix
Take the last two segments as `component`/`eventName` (short fixed literals,
never dotted) and everything before as `namespace`. No-op for the common
case; correct for dotted namespaces.

## Testing
Added `test/galaxy-client.test.js` using Node's built-in `node:test` (no new
runtime dependency). Run with `npm test`. A tiny zero-dependency ESM resolver
hook (`test/register.mjs`, `test/extensionless-resolver.mjs`) lets the test
import the bundler-style source directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)