### PR TITLE
Fix HTTP internal links to clickhouse.com on ClickGems pages

### DIFF
--- a/src/app/dashboard/[package_name]/page.js
+++ b/src/app/dashboard/[package_name]/page.js
@@ -201,7 +201,7 @@ export default async function Dashboard({ params, searchParams }) {
               Powered by &nbsp;
               <a
                 className='text-primary-300 hover:underline'
-                href='http://clickhouse.com/'
+                href='https://clickhouse.com/'
                 target='_blank'>
                 ClickHouse
               </a>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -27,7 +27,7 @@ export default function Header() {
                 Powered by &nbsp;
                 <a
                   className='text-primary-300 hover:underline'
-                  href='http://clickhouse.com/'
+                  href='https://clickhouse.com/'
                   target='_blank'>
                   ClickHouse
                 </a>


### PR DESCRIPTION
## Summary

An Ahrefs site audit ("HTTPS page has internal links to HTTP") flagged all ClickGems pages — the homepage and every `/dashboard/<gem>` page — for linking to `http://clickhouse.com/`, which 301-redirects to HTTPS.

Both occurrences are the "Powered by ClickHouse" link:

- `src/components/Header.jsx` (homepage header)
- `src/app/dashboard/[package_name]/page.js` (gem dashboard pages)

This changes them to `https://clickhouse.com/`, resolving the flagged rows for clickgems.clickhouse.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)